### PR TITLE
Added CMakeLists to simplify usage of library in CMake based projects.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,21 @@
+cmake_minimum_required(VERSION 3.1)
+project(tinyutf8)
+
+set(CMAKE_CXX_STANDARD 11)
+
+option(TINYUTF8_BUILD_TESTS "Build tests" Off)
+option(TINYUTF8_BUILD_STATIC "Build as static library" On)
+
+if (${TINYUTF8_BUILD_STATIC})
+   set(LIB_BUILD_TYPE STATIC)
+else()
+    set(LIB_BUILD_TYPE SHARED)
+endif()
+
+if (${TINYUTF8_BUILD_TESTS})
+    add_subdirectory(test)
+endif()
+
+add_library(tinyutf8 ${LIB_BUILD_TYPE} lib/tinyutf8.cpp)
+
+target_include_directories(tinyutf8 PUBLIC include)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,17 +3,12 @@ project(tinyutf8)
 
 set(CMAKE_CXX_STANDARD 11)
 
-option(TINYUTF8_BUILD_TESTS "Build tests" Off)
 option(TINYUTF8_BUILD_STATIC "Build as static library" On)
 
 if (${TINYUTF8_BUILD_STATIC})
    set(LIB_BUILD_TYPE STATIC)
 else()
     set(LIB_BUILD_TYPE SHARED)
-endif()
-
-if (${TINYUTF8_BUILD_TESTS})
-    add_subdirectory(test)
 endif()
 
 add_library(tinyutf8 ${LIB_BUILD_TYPE} lib/tinyutf8.cpp)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,8 +1,0 @@
-cmake_minimum_required(VERSION 3.1)
-
-set(CMAKE_CXX_STANDARD 11)
-
-add_executable(tinyutf8_test test.cpp)
-target_link_libraries(tinyutf8_test tinyutf8)
-
-configure_file(input.txt input.txt COPYONLY)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.1)
+
+set(CMAKE_CXX_STANDARD 11)
+
+add_executable(tinyutf8_test test.cpp)
+target_link_libraries(tinyutf8_test tinyutf8)
+
+configure_file(input.txt input.txt COPYONLY)


### PR DESCRIPTION
Also added ability to build tests with CMake: `cmake -DTINYUTF8_BUILD_TESTS=On` and selection between static of shared library build with `TINYUTF8_BUILD_STATIC` option (enabled by default).